### PR TITLE
But 298 add required apns headers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,3 @@ require (
 	golang.org/x/net v0.0.0-20190119204137-ed066c81e75e // indirect
 	gopkg.in/xmlpath.v2 v2.0.0-20150820204837-860cbeca3ebc
 )
-
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -4,3 +4,5 @@ require (
 	golang.org/x/net v0.0.0-20190119204137-ed066c81e75e // indirect
 	gopkg.in/xmlpath.v2 v2.0.0-20150820204837-860cbeca3ebc
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,11 @@
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 golang.org/x/net v0.0.0-20190119204137-ed066c81e75e h1:MDa3fSUp6MdYHouVmCCNz/zaH2a6CRcxY3VhT/K3C5Q=
 golang.org/x/net v0.0.0-20190119204137-ed066c81e75e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/xmlpath.v2 v2.0.0-20150820204837-860cbeca3ebc h1:LMEBgNcZUqXaP7evD1PZcL6EcDVa2QOFuI+cqM3+AJM=
 gopkg.in/xmlpath.v2 v2.0.0-20150820204837-860cbeca3ebc/go.mod h1:N8UOSI6/c2yOpa/XDz3KVUiegocTziPiqNkeNTMiG1k=

--- a/notihub/notihub.go
+++ b/notihub/notihub.go
@@ -257,6 +257,7 @@ func (h *NotificationHub) send(ctx context.Context, n *Notification, orTags []st
 		headers["ServiceBusNotification-Tags"] = strings.Join(orTags, " || ")
 	}
 
+	//IOS 13 and upwards require these headers to be set. They are not set by Notification Hub at the moment, so we need to send them
 	if n.Format == AppleFormat {
 		if isAppleBackgroundNotification(n.Payload) {
 			headers["X-Apns-Push-Type"] = "background"


### PR DESCRIPTION
From IOS 13 and upwards it is required to set the `apns-push-type` header. If the notification is a background notification the `apns-prority` header also needs to be set to "5". This is not handled by Notification Hub at the moment, so we need to set them ourselves. This will probably be provided by Notification Hub after a while, then this can be removed.

https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns